### PR TITLE
Fixed bug in MainWindServer.get_load

### DIFF
--- a/src/structuraltools/__init__.py
+++ b/src/structuraltools/__init__.py
@@ -14,10 +14,10 @@
 
 
 from structuraltools.unit import unit
-from structuraltools.utils import linterp, round_to
+from structuraltools.utils import convert_to_unit, linterp, round_to
 
 
 __all__ = (
-    linterp, round_to,
+    convert_to_unit, linterp, round_to,
     unit
 )

--- a/src/structuraltools/asce/wind_loading.py
+++ b/src/structuraltools/asce/wind_loading.py
@@ -445,7 +445,8 @@ class MainWindServer:
             if element == "parapet":
                 p = q_z*self.K_d*C_p
             else:
-                p = q_z*self.K_d*self.G[axis]*C_p+self.q_h*self.K_d*self.GC_pi*sign(C_p)
+                p_sign = sign(C_p) if sign(C_p) else 1
+                p = q_z*self.K_d*self.G[axis]*C_p+self.q_h*self.K_d*self.GC_pi*p_sign
             pressures.append(max(abs(p), p_min)*sign(p))
         return pressures
 

--- a/src/structuraltools/awc/chapter_4.py
+++ b/src/structuraltools/awc/chapter_4.py
@@ -46,7 +46,7 @@ def sec_4_1_3(t_nom: int, d_nom: int) -> str:
         return "Dimension"
 
 
-def sec_4_3_3(wet_service: bool, F_b: Stress, F_c: Stress, C_F: float,
+def sec_4_3_3(wet_service: bool, F_b: Stress, F_c: Stress, C_F: dict[str, float],
         classification: str, species: str) -> dict[str: float]:
     """Determine the wet service factors for sawn lumber according to
     Section 4.3.3 of the 2024 NDS
@@ -63,8 +63,8 @@ def sec_4_3_3(wet_service: bool, F_b: Stress, F_c: Stress, C_F: float,
     F_c : Stress
         Unmodified compression stress of the wood
 
-    C_F : float
-        Size factor for flexure
+    C_F : dict[str, float]
+        Size factor dictionary
 
     classification : str
         One of "Dimension", "Beam", or "Post" indicating the lumber classification
@@ -73,9 +73,9 @@ def sec_4_3_3(wet_service: bool, F_b: Stress, F_c: Stress, C_F: float,
         Wood species"""
     if wet_service:
         C_M = copy(chapter_4_data["C_M"][classification])
-        if classification == "Dimension" and F_b*C_F <= 1150*unit.psi:
+        if classification == "Dimension" and F_b*C_F["F_b"] <= 1150*unit.psi:
             C_M.update({"F_b": 1})
-        if classification == "Dimension" and F_c <= 750*unit.psi:
+        if classification == "Dimension" and F_c*C_F["F_c"] <= 750*unit.psi:
             C_M.update({"F_c": 1})
         if classification in ["Beam", "Post"] and "Southern Pine" in species:
             C_M.update({"F_c": 1, "F_c_perp": 1})

--- a/src/structuraltools/awc/members.py
+++ b/src/structuraltools/awc/members.py
@@ -17,9 +17,9 @@ import importlib.resources
 
 from numpy import ceil, sqrt
 
-from structuraltools.awc import chapter_4
+from structuraltools.awc import chapter_2, chapter_4
 from structuraltools.unit import Length
-from structuraltools.utils import read_data_table, Result, round_to
+from structuraltools.utils import pivot_dict_table, read_data_table, Result, round_to
 
 
 resources = importlib.resources.files("structuraltools.awc.resources")
@@ -56,6 +56,12 @@ class SawnLumber:
             the grade designation to indicate "Dense" or "& Btr" and a "-" can
             be appended to indicate "Non-Dense".
 
+        t : Length
+            Member thickness
+
+        d : Length
+            Member width
+
         wet_service : bool
             Boolean indicating if the wet service factor should be applied
 
@@ -72,8 +78,8 @@ class SawnLumber:
         # Calculate section properties
         self.d = abs(d.to("inch"))
         self.t = abs(t.to("inch"))
-        self.d_nom = ceil(self.d.magnitude)
-        self.t_nom = ceil(self.t.magnitude)
+        self.d_nom = int(ceil(self.d.magnitude))
+        self.t_nom = int(ceil(self.t.magnitude))
         self.A = (self.d*self.t).to("inch**2")
         self.S_x = (self.t*self.d**2/6).to("inch**3")
         self.I_x = (self.t*self.d**3/12).to("inch**4")
@@ -102,3 +108,14 @@ class SawnLumber:
 
 
         # Modification factors
+        C_F = chapter_4.sec_4_3_6(self.classification, self.species, self.grade,
+            self.t_nom, self.d_nom)
+        C_M = chapter_4.sec_4_3_3(wet_service, self.F_b, self.F_c, C_F,
+            self.classification, self.species)
+        C_t = chapter_2.sec_2_3_3(temperature, wet_service)
+        C_fu = chapter_4.sec_4_3_7(self.classification, self.grade,
+            self.t_nom, self.d_nom)
+        C_i = chapter_4.sec_4_3_8(incising)
+        self.modifiers = pivot_dict_table(
+            {"C_F": C_F, "C_M": C_M, "C_t": C_t, "C_fu": C_fu, "C_i": C_i})
+        print(self.modifiers)

--- a/src/structuraltools/awc/members.py
+++ b/src/structuraltools/awc/members.py
@@ -76,6 +76,7 @@ class SawnLumber:
 
 
         # Calculate section properties
+        self.c = 0.8  # Adjustment used when calculating the column stability factor
         self.d = abs(d.to("inch"))
         self.t = abs(t.to("inch"))
         self.d_nom = int(ceil(self.d.magnitude))
@@ -118,4 +119,3 @@ class SawnLumber:
         C_i = chapter_4.sec_4_3_8(incising)
         self.modifiers = pivot_dict_table(
             {"C_F": C_F, "C_M": C_M, "C_t": C_t, "C_fu": C_fu, "C_i": C_i})
-        print(self.modifiers)

--- a/src/structuraltools/awc/resources/SawnLumber.csv
+++ b/src/structuraltools/awc/resources/SawnLumber.csv
@@ -71,24 +71,24 @@ Dimension|Cottonwood|Stud,475 psi,275 psi,125 psi,320 psi,300 psi,1000000 psi,37
 Dimension|Cottonwood|Construction,700 psi,400 psi,125 psi,320 psi,650 psi,1000000 psi,370000 psi,0.41,NELMA
 Dimension|Cottonwood|Standard,400 psi,225 psi,125 psi,320 psi,500 psi,900000 psi,330000 psi,0.41,NELMA
 Dimension|Cottonwood|Utility,175 psi,100 psi,125 psi,320 psi,325 psi,900000 psi,330000 psi,0.41,NELMA
-Dimension|Douglas Fir|Select,1500 psi,1000 psi,180 psi,625 psi,1700 psi,1900000 psi,690000 psi,0.41,NELMA
-Dimension|Douglas Fir|1+,1200 psi,800 psi,180 psi,625 psi,1550 psi,1800000 psi,660000 psi,0.41,NELMA
-Dimension|Douglas Fir|1,1000 psi,675 psi,180 psi,625 psi,1500 psi,1700000 psi,620000 psi,0.41,NELMA
-Dimension|Douglas Fir|2,900 psi,575 psi,180 psi,625 psi,1350 psi,1600000 psi,580000 psi,0.41,NELMA
-Dimension|Douglas Fir|3,525 psi,325 psi,180 psi,625 psi,775 psi,1400000 psi,510000 psi,0.41,NELMA
-Dimension|Douglas Fir|Stud,700 psi,450 psi,180 psi,625 psi,850 psi,1400000 psi,510000 psi,0.41,NELMA
-Dimension|Douglas Fir|Construction,1000 psi,650 psi,180 psi,625 psi,1650 psi,1500000 psi,550000 psi,0.41,NELMA
-Dimension|Douglas Fir|Standard,575 psi,375 psi,180 psi,625 psi,1400 psi,1400000 psi,510000 psi,0.41,NELMA
-Dimension|Douglas Fir|Utility,275 psi,175 psi,180 psi,625 psi,900 psi,1300000 psi,470000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|Select,1350 psi,825 psi,180 psi,625 psi,1900 psi,1900000 psi,690000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|1+,1150 psi,750 psi,180 psi,625 psi,1800 psi,1800000 psi,660000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|1,850 psi,500 psi,180 psi,625 psi,1400 psi,1600000 psi,580000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|2,850 psi,500 psi,180 psi,625 psi,1400 psi,1600000 psi,580000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|3,475 psi,300 psi,180 psi,625 psi,825 psi,1400000 psi,510000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|Stud,650 psi,400 psi,180 psi,625 psi,900 psi,1400000 psi,510000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|Construction,950 psi,575 psi,180 psi,625 psi,1800 psi,1500000 psi,550000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|Standard,525 psi,325 psi,180 psi,625 psi,1450 psi,1400000 psi,510000 psi,0.41,NELMA
-Dimension|Douglas Fir (North)|Utility,250 psi,150 psi,180 psi,625 psi,950 psi,1300000 psi,470000 psi,0.41,NELMA
+Dimension|Douglas Fir|Select,1500 psi,1000 psi,180 psi,625 psi,1700 psi,1900000 psi,690000 psi,0.5,NELMA
+Dimension|Douglas Fir|1+,1200 psi,800 psi,180 psi,625 psi,1550 psi,1800000 psi,660000 psi,0.5,NELMA
+Dimension|Douglas Fir|1,1000 psi,675 psi,180 psi,625 psi,1500 psi,1700000 psi,620000 psi,0.5,NELMA
+Dimension|Douglas Fir|2,900 psi,575 psi,180 psi,625 psi,1350 psi,1600000 psi,580000 psi,0.5,NELMA
+Dimension|Douglas Fir|3,525 psi,325 psi,180 psi,625 psi,775 psi,1400000 psi,510000 psi,0.5,NELMA
+Dimension|Douglas Fir|Stud,700 psi,450 psi,180 psi,625 psi,850 psi,1400000 psi,510000 psi,0.5,NELMA
+Dimension|Douglas Fir|Construction,1000 psi,650 psi,180 psi,625 psi,1650 psi,1500000 psi,550000 psi,0.5,NELMA
+Dimension|Douglas Fir|Standard,575 psi,375 psi,180 psi,625 psi,1400 psi,1400000 psi,510000 psi,0.5,NELMA
+Dimension|Douglas Fir|Utility,275 psi,175 psi,180 psi,625 psi,900 psi,1300000 psi,470000 psi,0.5,NELMA
+Dimension|Douglas Fir (North)|Select,1350 psi,825 psi,180 psi,625 psi,1900 psi,1900000 psi,690000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|1+,1150 psi,750 psi,180 psi,625 psi,1800 psi,1800000 psi,660000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|1,850 psi,500 psi,180 psi,625 psi,1400 psi,1600000 psi,580000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|2,850 psi,500 psi,180 psi,625 psi,1400 psi,1600000 psi,580000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|3,475 psi,300 psi,180 psi,625 psi,825 psi,1400000 psi,510000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|Stud,650 psi,400 psi,180 psi,625 psi,900 psi,1400000 psi,510000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|Construction,950 psi,575 psi,180 psi,625 psi,1800 psi,1500000 psi,550000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|Standard,525 psi,325 psi,180 psi,625 psi,1450 psi,1400000 psi,510000 psi,0.49,NELMA
+Dimension|Douglas Fir (North)|Utility,250 psi,150 psi,180 psi,625 psi,950 psi,1300000 psi,470000 psi,0.49,NELMA
 Dimension|Douglas Fir (South)|Select,1350 psi,900 psi,180 psi,520 psi,1600 psi,1400000 psi,510000 psi,0.46,WWPA
 Dimension|Douglas Fir (South)|1,925 psi,600 psi,180 psi,520 psi,1450 psi,1300000 psi,470000 psi,0.46,WWPA
 Dimension|Douglas Fir (South)|2,850 psi,525 psi,180 psi,520 psi,1350 psi,1200000 psi,440000 psi,0.46,WWPA

--- a/src/structuraltools/utils.py
+++ b/src/structuraltools/utils.py
@@ -255,3 +255,18 @@ def read_data_table(filepath: str) -> pd.DataFrame:
     data_table = data_table.map(convert_to_unit)
     data_table = data_table.set_index(data_table.columns[0], drop=True)
     return data_table
+
+def pivot_dict_table(table: dict[any, dict[any, any]]) -> dict[any, dict[any, any]]:
+    """Pivot a table made of nested dictionaries
+
+    Parameters
+    ==========
+
+    table : dict[any, dict[any, any]]
+        Table to pivot"""
+    result = {}
+    for out_key, dictionary in table.items():
+        for in_key, value in dictionary.items():
+            result.update({in_key: result.get(in_key, {})})
+            result[in_key].update({out_key: value})
+    return result

--- a/tests/awc/test_chapter_4.py
+++ b/tests/awc/test_chapter_4.py
@@ -35,7 +35,7 @@ def test_sec_4_3_3():
         wet_service=True,
         F_b=1000*unit.psi,
         F_c=600*unit.psi,
-        C_F=1.1,
+        C_F={"F_b": 1.1, "F_c": 1.1},
         classification="Dimension",
         species="Southern Pine")
     assert C_M == {"F_b": 1, "F_t": 1, "F_v": 0.97, "F_c": 1,

--- a/tests/awc/test_members.py
+++ b/tests/awc/test_members.py
@@ -13,8 +13,69 @@
 # limitations under the License.
 
 
+from numpy import isclose
+
 from structuraltools.awc import members
+from structuraltools.unit import unit
 
 
-def test_SawnLumber_init():
-    assert False
+def test_SawnLumber_init_Dimensioned():
+    member = members.SawnLumber(
+        species="Douglas Fir",
+        grade="Select",
+        t=1.5*unit.inch,
+        d=7.25*unit.inch,
+        temperature=125,
+        incising=True)
+    assert member.d_nom == 8
+    assert member.t_nom == 2
+    assert isclose(member.A, 10.875*unit.inch**2)
+    assert isclose(member.S_x, 13.140625*unit.inch**3)
+    assert isclose(member.I_x, 47.63476563*unit.inch**4, atol=1e-8*unit.inch**4)
+    assert isclose(member.r_x, 2.092894726*unit.inch, atol=1e-9*unit.inch)
+    assert isclose(member.S_y, 2.71875*unit.inch**3)
+    assert isclose(member.I_y, 2.0390625*unit.inch**4)
+    assert isclose(member.r_y, 0.4330127019*unit.inch, atol=1e-10*unit.inch)
+    assert member.F_b == 1500*unit.psi
+    assert member.F_t == 1000*unit.psi
+    assert member.F_v == 180*unit.psi
+    assert member.F_c_perp == 625*unit.psi
+    assert member.F_c == 1700*unit.psi
+    assert member.E == 1900000*unit.psi
+    assert member.E_min == 690000*unit.psi
+    assert member.G == 0.5
+    assert member.modifiers == {
+        "F_b": {"C_F": 1.2, "C_M": 1, "C_t": 0.8, "C_fu": 1.15, "C_i": 0.8},
+        "F_t": {"C_F": 1.2, "C_M": 1, "C_t": 0.9, "C_fu": 1, "C_i": 0.8},
+        "F_v": {"C_F": 1, "C_M": 1, "C_t": 0.8, "C_fu": 1, "C_i": 0.8},
+        "F_c": {"C_F": 1.05, "C_M": 1, "C_t": 0.8, "C_fu": 1, "C_i": 0.8},
+        "F_c_perp": {"C_F": 1, "C_M": 1, "C_t": 0.8, "C_fu": 1, "C_i": 1},
+        "E": {"C_F": 1, "C_M": 1, "C_t": 0.9, "C_fu": 1, "C_i": 0.95},
+        "E_min": {"C_F": 1, "C_M": 1, "C_t": 0.9, "C_fu": 1, "C_i": 0.95}
+    }
+
+def test_SawnLumber_init_Dimensioned_Southern_Pine():
+    member = members.SawnLumber(
+        species="Southern Pine",
+        grade="1+",
+        t=1.5*unit.inch,
+        d=5.5*unit.inch,
+        wet_service=True)
+    assert member.F_b == 1500*unit.psi
+    assert member.F_t == 1000*unit.psi
+    assert member.F_v == 175*unit.psi
+    assert member.F_c_perp == 660*unit.psi
+    assert member.F_c == 1650*unit.psi
+    assert member.E == 1800000*unit.psi
+    assert member.E_min == 660000*unit.psi
+    assert member.G == 0.55
+    assert member.modifiers == {
+        "F_b": {"C_F": 1, "C_M": 0.85, "C_t": 1, "C_fu": 1.15, "C_i": 1},
+        "F_t": {"C_F": 1, "C_M": 1, "C_t": 1, "C_fu": 1, "C_i": 1},
+        "F_v": {"C_F": 1, "C_M": 0.97, "C_t": 1, "C_fu": 1, "C_i": 1},
+        "F_c": {"C_F": 1, "C_M": 0.8, "C_t": 1, "C_fu": 1, "C_i": 1},
+        "F_c_perp": {"C_F": 1, "C_M": 0.67, "C_t": 1, "C_fu": 1, "C_i": 1},
+        "E": {"C_F": 1, "C_M": 0.9, "C_t": 1, "C_fu": 1, "C_i": 1},
+        "E_min": {"C_F": 1, "C_M": 0.9, "C_t": 1, "C_fu": 1, "C_i": 1}
+    }
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,3 +72,7 @@ def test_read_data_table():
     filepath = resources.joinpath("steel_materials.csv")
     steel_table = utils.read_data_table(filepath)
     assert steel_table.at["A36", "F_y"] == 36*unit.ksi
+
+def test_pivot_dict_table():
+    result = utils.pivot_dict_table({"a": {"1": 1, "2": 2}, "b": {"1": 3, "2": 4}})
+    assert result == {"1": {"a": 1, "b": 3}, "2": {"a": 2, "b": 4}}


### PR DESCRIPTION
Fixed a bug in `MainWindServer.get_load` that caused a value of 0 psf to be returned when the pressure coefficient for the area was 0. The fix does force the result to a positive pressure, so a more thorough fix that addresses the usability issues of returning two values should be considered.